### PR TITLE
chore: update .gitignore to exclude Visual Studio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules
 *.launch
 .settings/
 *.sublime-workspace
+.vs
 
 # IDE - VSCode
 .vscode/*


### PR DESCRIPTION
Added .vs to the .gitignore file to prevent Visual Studio workspace files
from being tracked in the repository.