### PR TITLE
deps: Update FastEndpoints to version 6.0.0

### DIFF
--- a/apps/api-demo/ApiDemo.csproj
+++ b/apps/api-demo/ApiDemo.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="5.35.0" />
-    <PackageReference Include="FastEndpoints.ClientGen.Kiota" Version="5.35.0" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="5.35.0" />
+    <PackageReference Include="FastEndpoints" Version="6.0.0" />
+    <PackageReference Include="FastEndpoints.ClientGen.Kiota" Version="6.0.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/apps/dotnet-fe-auth/dotnet-fe-auth.csproj
+++ b/apps/dotnet-fe-auth/dotnet-fe-auth.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastEndpoints" Version="5.35.0" />
-    <PackageReference Include="FastEndpoints.Security" Version="5.35.0" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="5.35.0" />
+    <PackageReference Include="FastEndpoints" Version="6.0.0" />
+    <PackageReference Include="FastEndpoints.Security" Version="6.0.0" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     <PackageReference Include="NSwag.MSBuild" Version="14.2.0">


### PR DESCRIPTION
Upgrade FastEndpoints and its related packages to version 6.0.0 in the api-demo and dotnet-fe-auth projects.