### PR TITLE
fix: FastEndpoints Onefile serialization issue

### DIFF
--- a/apps/fe_onefile/FE_OneFile.cs
+++ b/apps/fe_onefile/FE_OneFile.cs
@@ -28,5 +28,7 @@ public class MyEndpoint : Endpoint<MyRequest, MyResponse>
         Send.OkAsync(new($"{req.FirstName} {req.LastName}", req.Age >= 18), cancellation: ct);
 }
 
-[JsonSerializable(typeof(MyRequest)), JsonSerializable(typeof(MyResponse))]
+[JsonSerializable(typeof(MyRequest)),
+ JsonSerializable(typeof(MyResponse)),
+ JsonSerializable(typeof(IEnumerable<string>))]
 internal partial class AppJsonSerializerContext : JsonSerializerContext;


### PR DESCRIPTION
Enhance the serialization context by adding support for `IEnumerable<string>` in the FastEndpoints Onefile implementation.