### PR TITLE
chore: upgrade FastEndpoints to v8.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
     <!-- Code coverage -->
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <!-- FastEndpoints -->
-    <PackageVersion Include="FastEndpoints" Version="7.2.0" />
-    <PackageVersion Include="FastEndpoints.ClientGen.Kiota" Version="7.2.0" />
-    <PackageVersion Include="FastEndpoints.Security" Version="7.2.0" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="7.2.0" />
+    <PackageVersion Include="FastEndpoints" Version="8.0.0" />
+    <PackageVersion Include="FastEndpoints.ClientGen.Kiota" Version="8.0.0" />
+    <PackageVersion Include="FastEndpoints.Security" Version="8.0.0" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="8.0.0" />
     <!-- Microsoft.AspNetCore -->
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />

--- a/apps/fe_onefile/FE_OneFile.cs
+++ b/apps/fe_onefile/FE_OneFile.cs
@@ -1,5 +1,5 @@
 #:sdk Microsoft.NET.Sdk.Web
-#:package FastEndpoints@7.*-*
+#:package FastEndpoints@8.*-*
 
 using FastEndpoints;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
Update FastEndpoints packages in api-demo and dotnet-fe-auth to 8.0.0, and bump the one-file sample's package directive to v8.