### PR TITLE
Add A2A demo with FastEndpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 - Runbook: see `apps/a2a-demo/README.md` for start order, commands, and expected output.
 - Scope: standalone single-file apps; intentionally not wired into Nx project graph or `nx-tinker.slnx`.
 
+## A2A demo (FastEndpoints)
+
+- Location: `apps/a2a-demo-fastendpoints`.
+- Purpose: local keyless proof-of-concept with the same specialist/coordinator design, implemented with `FastEndpoints.A2A` skill opt-in and dispatcher routes.
+- Runbook: see `apps/a2a-demo-fastendpoints/README.md`.
+- Scope: standalone single-file apps; intentionally not wired into Nx project graph or `nx-tinker.slnx`.
+
 ## FakeLogger demo
 
 - Location: `apps/fakelogger-demo` (app) and `apps/fakelogger-demo.Test` (tests).

--- a/apps/a2a-demo-fastendpoints/README.md
+++ b/apps/a2a-demo-fastendpoints/README.md
@@ -1,0 +1,67 @@
+# A2A Demo FastEndpoints (Single-File .NET PoC)
+
+This folder mirrors the design of apps/a2a-demo, but uses FastEndpoints.A2A skill opt-in and dispatcher wiring.
+
+Scope:
+
+- Standalone single-file apps under apps/a2a-demo-fastendpoints
+- Not wired into nx-tinker.slnx or Nx project graph
+- Local deterministic behavior (no cloud keys)
+
+## Apps
+
+- specialist/specialist.cs
+  - Hosts FE specialist agent on http://localhost:5162
+  - A2A routes: /a2a and /.well-known/agent-card.json
+  - Skill id: specialist_uppercase
+- coordinator/coordinator.cs
+  - Server mode: hosts FE coordinator agent on http://localhost:5163
+  - Client mode: calls specialist or coordinator via A2A discovery
+  - Skill id: coordinator_delegate
+
+## Run
+
+Open two terminals for server mode and optional third for client mode.
+
+1. Start specialist server
+
+```powershell
+dotnet run apps/a2a-demo-fastendpoints/specialist/specialist.cs
+```
+
+2. Start coordinator server
+
+```powershell
+dotnet run apps/a2a-demo-fastendpoints/coordinator/coordinator.cs
+```
+
+3. Client mode: direct call to specialist
+
+```powershell
+dotnet run apps/a2a-demo-fastendpoints/coordinator/coordinator.cs -- --client --target specialist --message "hello specialist"
+```
+
+4. Client mode: call coordinator (delegates to specialist)
+
+```powershell
+dotnet run apps/a2a-demo-fastendpoints/coordinator/coordinator.cs -- --client --target coordinator --message "delegate this"
+```
+
+## Expected Output
+
+- Specialist call:
+  - SPECIALIST::HELLO SPECIALIST
+- Coordinator call:
+  - COORDINATOR::delegate this => SPECIALIST::DELEGATE THIS
+
+## HTTP Smoke Tests
+
+Use VS Code REST Client on:
+
+- specialist/test.http
+- coordinator/test.http
+
+## Notes
+
+- This demo uses FastEndpoints A2A opt-in metadata with this.A2ASkill(...) in each endpoint Configure() method.
+- FastEndpoints currently supports A2A SendMessage with JSON-RPC binding; this demo stays within that path.

--- a/apps/a2a-demo-fastendpoints/coordinator/coordinator.cs
+++ b/apps/a2a-demo-fastendpoints/coordinator/coordinator.cs
@@ -1,0 +1,195 @@
+#:sdk Microsoft.NET.Sdk.Web
+#:package FastEndpoints@8.*-*
+#:package FastEndpoints.A2A@1.0.0-beta.1
+#:package A2A@1.*-*
+#:property ManagePackageVersionsCentrally=false
+
+using A2A;
+using FastEndpoints;
+using FastEndpoints.A2A;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+const string CoordinatorHostUrl = "http://localhost:5163";
+const string SpecialistBaseUrl = "http://localhost:5162/";
+
+if (args.Contains("--client", StringComparer.OrdinalIgnoreCase))
+{
+    await RunClientModeAsync(args);
+    return;
+}
+
+var bld = WebApplication.CreateBuilder(args);
+bld.WebHost.UseUrls(CoordinatorHostUrl);
+bld.Services.ConfigureHttpJsonOptions(o => o.SerializerOptions.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver()));
+
+bld.Services
+   .AddFastEndpoints()
+   .AddA2A(o =>
+   {
+       o.AgentName = "fe-coordinator-agent";
+       o.Description = "FastEndpoints coordinator agent for local A2A demos.";
+       o.Version = "1.0.0";
+       o.SkillVisibilityFilter = (_, _, _) => true;
+   });
+
+var app = bld.Build();
+
+app.UseFastEndpoints()
+    .UseA2A(rpcPattern: "/a2a", agentCardPattern: "/.well-known/agent-card.json");
+
+app.Run();
+
+static async Task RunClientModeAsync(string[] args)
+{
+    var target = FastA2AHelpers.GetOption(args, "--target")?.ToLowerInvariant() ?? "specialist";
+    var input = FastA2AHelpers.GetOption(args, "--message") ?? "hello from FE A2A client mode";
+
+    var baseUrl = target == "coordinator" ? CoordinatorHostUrl : SpecialistBaseUrl;
+    var skillId = target == "coordinator" ? "coordinator_delegate" : "specialist_uppercase";
+
+    var response = await FastA2AHelpers.CallSkillAsync(baseUrl, skillId, input);
+
+    Console.WriteLine($"Target: {target}");
+    Console.WriteLine($"Input: {input}");
+    Console.WriteLine($"Response: {response}");
+}
+
+sealed class CoordinatorEndpoint : Endpoint<CoordinatorRequest, CoordinatorResponse>
+{
+    public override void Configure()
+    {
+        Post("/skills/coordinator-delegate");
+        AllowAnonymous();
+
+        this.A2ASkill(
+            id: "coordinator_delegate",
+            tags: ["demo", "delegation", "a2a"],
+            configure: skill =>
+            {
+                skill.Name = "Coordinator Delegate";
+                skill.Description = "Delegates Input to specialist_uppercase and composes a deterministic response.";
+                skill.Examples = ["Delegate this message to specialist."];
+                skill.InputModes = ["application/json"];
+                skill.OutputModes = ["application/json"];
+            });
+    }
+
+    public override async Task HandleAsync(CoordinatorRequest req, CancellationToken ct)
+    {
+        var input = req.Input ?? string.Empty;
+        var specialist = await FastA2AHelpers.CallSkillAsync("http://localhost:5162/", "specialist_uppercase", input);
+
+        await Send.OkAsync(new CoordinatorResponse($"COORDINATOR::{input} => {specialist}"), ct);
+    }
+}
+
+sealed record CoordinatorRequest(string? Input);
+sealed record CoordinatorResponse(string Result);
+
+file static class FastA2AHelpers
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+    };
+
+    public static string? GetOption(string[] args, string option)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], option, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+
+        return null;
+    }
+
+    public static async Task<string> CallSkillAsync(string baseUrl, string skillId, string input)
+    {
+        try
+        {
+            var resolver = new A2ACardResolver(new Uri(baseUrl));
+            var card = await resolver.GetAgentCardAsync();
+            var rpcUrl = card.SupportedInterfaces?.FirstOrDefault()?.Url;
+
+            if (string.IsNullOrWhiteSpace(rpcUrl))
+            {
+                return "ERROR::No supported interface URL in agent card.";
+            }
+
+            var payload = JsonSerializer.SerializeToElement(new SkillInput(input), JsonOptions);
+            var metadata = new Dictionary<string, JsonElement>
+            {
+                ["skill"] = JsonSerializer.SerializeToElement(skillId, JsonOptions)
+            };
+
+            var client = new A2AClient(new Uri(rpcUrl));
+            var response = await client.SendMessageAsync(new SendMessageRequest
+            {
+                Message = new Message
+                {
+                    MessageId = Guid.NewGuid().ToString("N"),
+                    Role = Role.User,
+                    Parts = [Part.FromData(payload)]
+                },
+                Metadata = metadata
+            });
+
+            var part = response.Message?.Parts?.FirstOrDefault();
+            if (part?.Data is { } data)
+            {
+                if (TryReadResult(data, out var result))
+                {
+                    return result;
+                }
+
+                return data.GetRawText();
+            }
+
+            if (!string.IsNullOrWhiteSpace(part?.Text))
+            {
+                return part.Text;
+            }
+
+            return response.PayloadCase switch
+            {
+                SendMessageResponseCase.Task => $"TASK::{response.Task?.Id}",
+                SendMessageResponseCase.Message => "ERROR::Message response had no readable part.",
+                _ => "ERROR::Unexpected response payload."
+            };
+        }
+        catch (Exception ex)
+        {
+            return $"ERROR::{ex.Message}";
+        }
+    }
+
+    private static bool TryReadResult(JsonElement data, out string result)
+    {
+        result = string.Empty;
+
+        if (data.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (data.TryGetProperty("Result", out var upper) && upper.ValueKind == JsonValueKind.String)
+        {
+            result = upper.GetString() ?? string.Empty;
+            return true;
+        }
+
+        if (data.TryGetProperty("result", out var lower) && lower.ValueKind == JsonValueKind.String)
+        {
+            result = lower.GetString() ?? string.Empty;
+            return true;
+        }
+
+        return false;
+    }
+
+    private sealed record SkillInput(string Input);
+}

--- a/apps/a2a-demo-fastendpoints/coordinator/test.http
+++ b/apps/a2a-demo-fastendpoints/coordinator/test.http
@@ -1,0 +1,33 @@
+@host = http://localhost:5163
+
+### Server info
+GET {{host}}/
+
+### Well-known agent card
+GET {{host}}/.well-known/agent-card.json
+
+### Direct A2A JSON-RPC call to coordinator skill (delegates to specialist)
+POST {{host}}/a2a
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "SendMessage",
+  "params": {
+    "message": {
+      "messageId": "local-client-2",
+      "role": "user",
+      "parts": [
+        {
+          "data": {
+            "Input": "delegate this"
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "skill": "coordinator_delegate"
+    }
+  }
+}

--- a/apps/a2a-demo-fastendpoints/specialist/specialist.cs
+++ b/apps/a2a-demo-fastendpoints/specialist/specialist.cs
@@ -1,0 +1,58 @@
+#:sdk Microsoft.NET.Sdk.Web
+#:package FastEndpoints@8.*-*
+#:package FastEndpoints.A2A@1.0.0-beta.1
+#:property ManagePackageVersionsCentrally=false
+
+using FastEndpoints;
+using FastEndpoints.A2A;
+using System.Text.Json.Serialization.Metadata;
+
+const string HostUrl = "http://localhost:5162";
+
+var bld = WebApplication.CreateBuilder(args);
+bld.WebHost.UseUrls(HostUrl);
+bld.Services.ConfigureHttpJsonOptions(o => o.SerializerOptions.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver()));
+
+bld.Services
+   .AddFastEndpoints()
+   .AddA2A(o =>
+   {
+       o.AgentName = "fe-specialist-agent";
+       o.Description = "FastEndpoints specialist agent for local A2A demos.";
+       o.Version = "1.0.0";
+       o.SkillVisibilityFilter = (_, _, _) => true;
+   });
+
+var app = bld.Build();
+
+app.UseFastEndpoints()
+    .UseA2A(rpcPattern: "/a2a", agentCardPattern: "/.well-known/agent-card.json");
+
+app.Run();
+
+sealed class SpecialistEndpoint : Endpoint<SpecialistRequest, SpecialistResponse>
+{
+    public override void Configure()
+    {
+        Post("/skills/specialist-uppercase");
+        AllowAnonymous();
+
+        this.A2ASkill(
+            id: "specialist_uppercase",
+            tags: ["demo", "transform", "uppercase"],
+            configure: skill =>
+            {
+                skill.Name = "Specialist Uppercase";
+                skill.Description = "Uppercases the Input text and returns a deterministic marker.";
+                skill.Examples = ["Transform hello to uppercase."];
+                skill.InputModes = ["application/json"];
+                skill.OutputModes = ["application/json"];
+            });
+    }
+
+    public override Task HandleAsync(SpecialistRequest req, CancellationToken ct)
+        => Send.OkAsync(new SpecialistResponse($"SPECIALIST::{(req.Input ?? string.Empty).ToUpperInvariant()}"), ct);
+}
+
+sealed record SpecialistRequest(string? Input);
+sealed record SpecialistResponse(string Result);

--- a/apps/a2a-demo-fastendpoints/specialist/test.http
+++ b/apps/a2a-demo-fastendpoints/specialist/test.http
@@ -1,0 +1,33 @@
+@host = http://localhost:5162
+
+### Server info
+GET {{host}}/
+
+### Well-known agent card
+GET {{host}}/.well-known/agent-card.json
+
+### Direct A2A JSON-RPC call to specialist skill
+POST {{host}}/a2a
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "SendMessage",
+  "params": {
+    "message": {
+      "messageId": "local-client-1",
+      "role": "user",
+      "parts": [
+        {
+          "data": {
+            "Input": "hello specialist"
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "skill": "specialist_uppercase"
+    }
+  }
+}


### PR DESCRIPTION
Introduce a proof-of-concept for A2A communication using FastEndpoints, featuring specialist and coordinator agents. Include run instructions and HTTP tests for local deployment.