### PR TITLE
feat: automate dependabot npm override cleanup

### DIFF
--- a/.github/workflows/pull_request_dependabot.yml
+++ b/.github/workflows/pull_request_dependabot.yml
@@ -29,8 +29,9 @@ jobs:
       dependency-names: ${{ steps.metadata.outputs.dependency-names }}
       update-type: ${{ steps.metadata.outputs.update-type }}
       dependency-versions: ${{ steps.metadata.outputs.new-version }}
+      package-ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}
       updated-dependencies-json: ${{ steps.metadata.outputs.updated-dependencies-json }}
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]'}}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && (github.event.action == 'opened' || (github.event.action == 'synchronize' && github.event.sender.login == 'dependabot[bot]')) }}
     steps:
       - name: Fetch dependabot metadata
         id: metadata
@@ -39,22 +40,96 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           skip-commit-verification: true
 
-  nx-migrate:
-    name: "NX Migrate"
+  override-cleanup:
+    name: "Override cleanup"
     runs-on: ubuntu-latest
     needs: dependabot-check
     if: always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       (github.event.action == 'opened' || (github.event.action == 'synchronize' && github.event.sender.login == 'dependabot[bot]')) &&
-      (contains(needs.dependabot-check.outputs.dependency-names, '@nx/') || contains(needs.dependabot-check.outputs.dependency-names, 'nx')) || (inputs.nx_update == 'true')
+      needs.dependabot-check.outputs.package-ecosystem == 'npm'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: "Checkout code for Nx updates"
+      - name: "Checkout code for override cleanup"
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - name: Restore NuGet packages
+        run: dotnet restore nx-tinker.slnx
+      - name: Derive appropriate SHAs for `nx affected`
+        id: setSHAs
+        uses: nrwl/nx-set-shas@v5
+      - name: Install dependencies
+        run: npm ci
+      - name: Set user to github actions
+        run: |
+          git config --global user.email "dependabot[bot]@users.noreply.github.com"
+          git config --global user.name "dependabot[bot]"
+      - name: Reconcile npm overrides
+        env:
+          UPDATED_DEPS_JSON: ${{ needs.dependabot-check.outputs.updated-dependencies-json }}
+          DEPENDENCY_NAMES: ${{ needs.dependabot-check.outputs.dependency-names }}
+        run: |
+          node scripts/reconcile-dependabot-overrides.js \
+            --updated-dependencies-json "$UPDATED_DEPS_JSON" \
+            --dependency-names "$DEPENDENCY_NAMES" \
+            --report-path "tmp/dependabot-override-report.json"
+      - name: Commit override cleanup
+        run: |
+          if [ ! -f tmp/dependabot-override-report.json ]; then
+            echo "No override report found"
+            exit 0
+          fi
+          node -e "const fs=require('fs'); const report=JSON.parse(fs.readFileSync('tmp/dependabot-override-report.json','utf8')); if (!report.applied) process.exit(0); const names=report.removedOverrides.map((entry) => entry.dependencyName).join(', '); const message=report.removedOverrides.length === 1 ? 'chore(deps): remove unneeded override for ' + names : 'chore(deps): remove unneeded npm overrides'; fs.writeFileSync('tmp/dependabot-override-commit-message.txt', message + '\n');"
+          if [ -f tmp/dependabot-override-commit-message.txt ]; then
+            git add package.json package-lock.json
+            if git commit -F tmp/dependabot-override-commit-message.txt; then
+              git push origin ${{ github.event.pull_request.head.ref }} --force
+            else
+              echo "No override cleanup changes to commit"
+            fi
+          fi
+
+  nx-migrate:
+    name: "NX Migrate"
+    runs-on: ubuntu-latest
+    needs: [dependabot-check, override-cleanup]
+    if: always() &&
+      (
+        inputs.nx_update == 'true' ||
+        (
+          github.event_name == 'pull_request' &&
+          (github.event.action == 'opened' || (github.event.action == 'synchronize' && github.event.sender.login == 'dependabot[bot]')) &&
+          (
+            contains(needs.dependabot-check.outputs.dependency-names, '@nx/') ||
+            contains(needs.dependabot-check.outputs.dependency-names, 'nx')
+          )
+        )
+      )
+    steps:
+      - name: "Checkout code for Dependabot automation"
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Run npm install"
         run: |
-          npm i
+          npm ci
         working-directory: ${{ github.workspace }}
       - name: Set user to github actions
         run: |

--- a/scripts/reconcile-dependabot-overrides.js
+++ b/scripts/reconcile-dependabot-overrides.js
@@ -11,11 +11,20 @@ const {
 
 function parseArgs() {
   const args = {};
-  for (const arg of process.argv.slice(2)) {
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
     if (!arg.startsWith('--')) continue;
     const eq = arg.indexOf('=');
     if (eq === -1) {
-      args[arg.slice(2)] = true;
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        args[key] = next;
+        i += 1;
+      } else {
+        args[key] = true;
+      }
       continue;
     }
     args[arg.slice(2, eq)] = arg.slice(eq + 1);
@@ -197,11 +206,19 @@ function runNxValidation(cwd) {
 
 function restoreWorkspace(snapshot, cwd) {
   fs.writeFileSync(snapshot.packageJsonPath, snapshot.packageJson, 'utf8');
-  if (snapshot.packageLockPath && typeof snapshot.packageLock === 'string') {
-    fs.writeFileSync(snapshot.packageLockPath, snapshot.packageLock, 'utf8');
+  const hasPackageLockSnapshot = typeof snapshot.packageLock === 'string';
+  if (snapshot.packageLockPath) {
+    if (hasPackageLockSnapshot) {
+      fs.writeFileSync(snapshot.packageLockPath, snapshot.packageLock, 'utf8');
+    } else if (fs.existsSync(snapshot.packageLockPath)) {
+      fs.unlinkSync(snapshot.packageLockPath);
+    }
   }
 
-  const restore = runCommand('npm ci', cwd);
+  const restore = runCommand(
+    hasPackageLockSnapshot ? 'npm ci' : 'npm install --no-package-lock',
+    cwd,
+  );
   if (!restore.ok) {
     throw new Error(
       `Failed to restore workspace: ${restore.error || restore.stderr || restore.stdout}`,

--- a/scripts/reconcile-dependabot-overrides.js
+++ b/scripts/reconcile-dependabot-overrides.js
@@ -1,0 +1,427 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const {
+  removeNestedOverrideByPackageName,
+} = require('./process-dependabot-alerts');
+
+function parseArgs() {
+  const args = {};
+  for (const arg of process.argv.slice(2)) {
+    if (!arg.startsWith('--')) continue;
+    const eq = arg.indexOf('=');
+    if (eq === -1) {
+      args[arg.slice(2)] = true;
+      continue;
+    }
+    args[arg.slice(2, eq)] = arg.slice(eq + 1);
+  }
+  return args;
+}
+
+function tryParseJson(text) {
+  if (typeof text !== 'string' || !text.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function getDependencyName(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const candidates = [
+    entry['dependency-name'],
+    entry.dependency_name,
+    entry['package-name'],
+    entry.package_name,
+    entry.name,
+    entry.package,
+    entry.dependency &&
+      entry.dependency.package &&
+      entry.dependency.package.name,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function collectUpdatedDependencyNames(updatedDependenciesJson, dependencyNames) {
+  const names = new Set();
+
+  const addName = (value) => {
+    if (typeof value === 'string' && value.trim()) {
+      names.add(value.trim());
+    }
+  };
+
+  const addFromArray = (arr) => {
+    if (!Array.isArray(arr)) return;
+    for (const entry of arr) {
+      const name = getDependencyName(entry);
+      if (name) addName(name);
+    }
+  };
+
+  const parsedUpdatedDeps = tryParseJson(updatedDependenciesJson);
+  if (Array.isArray(parsedUpdatedDeps)) {
+    addFromArray(parsedUpdatedDeps);
+  } else if (parsedUpdatedDeps && typeof parsedUpdatedDeps === 'object') {
+    addFromArray([parsedUpdatedDeps]);
+  }
+
+  if (typeof dependencyNames === 'string' && dependencyNames.trim()) {
+    for (const name of dependencyNames.split(',')) {
+      addName(name);
+    }
+  } else if (Array.isArray(dependencyNames)) {
+    for (const name of dependencyNames) addName(name);
+  }
+
+  return Array.from(names);
+}
+
+function runCommand(command, cwd) {
+  try {
+    const stdout = cp.execSync(command, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, command, stdout: stdout || '', stderr: '' };
+  } catch (err) {
+    return {
+      ok: false,
+      command,
+      stdout: err && err.stdout ? String(err.stdout) : '',
+      stderr: err && err.stderr ? String(err.stderr) : '',
+      error: err && err.message ? String(err.message) : 'command failed',
+    };
+  }
+}
+
+function writeJsonFile(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function summarizeAuditResult(raw) {
+  const vulnerabilities =
+    raw &&
+    raw.metadata &&
+    raw.metadata.vulnerabilities &&
+    typeof raw.metadata.vulnerabilities === 'object'
+      ? raw.metadata.vulnerabilities
+      : null;
+
+  if (!vulnerabilities) {
+    return {
+      ok: false,
+      total: null,
+      vulnerabilities: null,
+    };
+  }
+
+  const total = Number.parseInt(String(vulnerabilities.total || 0), 10);
+  return {
+    ok: Number.isFinite(total),
+    total: Number.isFinite(total) ? total : null,
+    vulnerabilities,
+  };
+}
+
+function runNpmAudit(cwd) {
+  const res = runCommand('npm audit --json', cwd);
+  const parsed = tryParseJson(res.stdout) || tryParseJson(res.stderr);
+  const summary = summarizeAuditResult(parsed);
+  return {
+    ok: summary.ok,
+    command: res.command,
+    stdout: res.stdout,
+    stderr: res.stderr,
+    error: res.error || null,
+    raw: parsed,
+    summary,
+  };
+}
+
+function removeMatchingOverrides(overrides, dependencyNames) {
+  if (!overrides || typeof overrides !== 'object' || Array.isArray(overrides)) {
+    return [];
+  }
+
+  const removed = [];
+  const seen = new Set();
+  for (const dependencyName of dependencyNames) {
+    if (seen.has(dependencyName)) continue;
+    seen.add(dependencyName);
+
+    const result = removeNestedOverrideByPackageName(overrides, dependencyName);
+    if (result.removed) {
+      removed.push({
+        dependencyName,
+        removedPath: result.removedPath,
+      });
+    }
+  }
+
+  return removed;
+}
+
+function runNxValidation(cwd) {
+  const checks = {};
+  for (const target of ['build', 'test', 'lint']) {
+    const res = runCommand(`npx nx affected --target=${target}`, cwd);
+    checks[target] = res;
+    if (!res.ok) {
+      return {
+        ok: false,
+        checks,
+        failedTarget: target,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    checks,
+    failedTarget: null,
+  };
+}
+
+function restoreWorkspace(snapshot, cwd) {
+  fs.writeFileSync(snapshot.packageJsonPath, snapshot.packageJson, 'utf8');
+  if (snapshot.packageLockPath && typeof snapshot.packageLock === 'string') {
+    fs.writeFileSync(snapshot.packageLockPath, snapshot.packageLock, 'utf8');
+  }
+
+  const restore = runCommand('npm ci', cwd);
+  if (!restore.ok) {
+    throw new Error(
+      `Failed to restore workspace: ${restore.error || restore.stderr || restore.stdout}`,
+    );
+  }
+}
+
+function buildReport(reportPath, report) {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  writeJsonFile(reportPath, report);
+}
+
+async function main() {
+  const args = parseArgs();
+  const repoRoot = process.cwd();
+  const packageJsonPath = path.resolve(
+    repoRoot,
+    args['package-json-path'] || 'package.json',
+  );
+  const packageLockPath = path.resolve(
+    path.dirname(packageJsonPath),
+    args['package-lock-path'] || 'package-lock.json',
+  );
+  const reportPath = path.resolve(
+    repoRoot,
+    args['report-path'] || path.join('tmp', 'dependabot-override-report.json'),
+  );
+
+  const updatedDependenciesJson =
+    args['updated-dependencies-json'] ||
+    process.env.UPDATED_DEPS_JSON ||
+    process.env.UPDATED_DEPS ||
+    '';
+  const dependencyNames =
+    args['dependency-names'] || process.env.DEPENDENCY_NAMES || '';
+
+  const updatedDependencyNames = collectUpdatedDependencyNames(
+    updatedDependenciesJson,
+    dependencyNames,
+  );
+
+  const report = {
+    applied: false,
+    reverted: false,
+    reason: 'no-updated-dependencies',
+    packageJsonPath: path.relative(repoRoot, packageJsonPath),
+    packageLockPath: path.relative(repoRoot, packageLockPath),
+    updatedDependencyNames,
+    removedOverrides: [],
+    auditBefore: null,
+    auditAfter: null,
+    validation: null,
+  };
+
+  if (!updatedDependencyNames.length) {
+    buildReport(reportPath, report);
+    console.log('No Dependabot dependency names were provided.');
+    return 0;
+  }
+
+  if (!fs.existsSync(packageJsonPath)) {
+    report.reason = 'package-json-missing';
+    buildReport(reportPath, report);
+    console.log('Root package.json not found; skipping override reconciliation.');
+    return 0;
+  }
+
+  const originalPackageJsonText = fs.readFileSync(packageJsonPath, 'utf8');
+  const originalPackageJson = JSON.parse(originalPackageJsonText);
+  const originalPackageLock = fs.existsSync(packageLockPath)
+    ? fs.readFileSync(packageLockPath, 'utf8')
+    : null;
+
+  if (!originalPackageJson.overrides) {
+    report.reason = 'no-overrides-present';
+    buildReport(reportPath, report);
+    console.log('package.json has no overrides section; nothing to reconcile.');
+    return 0;
+  }
+
+  const baselineAudit = runNpmAudit(repoRoot);
+  report.auditBefore = baselineAudit.summary;
+
+  const modifiedPackageJson = JSON.parse(originalPackageJsonText);
+  const removedOverrides = removeMatchingOverrides(
+    modifiedPackageJson.overrides,
+    updatedDependencyNames,
+  );
+
+  if (modifiedPackageJson.overrides &&
+    Object.keys(modifiedPackageJson.overrides).length === 0) {
+    delete modifiedPackageJson.overrides;
+  }
+
+  if (!removedOverrides.length) {
+    report.reason = 'no-matching-overrides';
+    buildReport(reportPath, report);
+    console.log('No matching overrides were found for the Dependabot update.');
+    return 0;
+  }
+
+  writeJsonFile(packageJsonPath, modifiedPackageJson);
+
+  const installRes = runCommand('npm i', repoRoot);
+  if (!installRes.ok) {
+    restoreWorkspace(
+      {
+        packageJsonPath,
+        packageJson: originalPackageJsonText,
+        packageLockPath,
+        packageLock: originalPackageLock,
+      },
+      repoRoot,
+    );
+    report.reverted = true;
+    report.reason = 'npm-install-failed';
+    report.removedOverrides = removedOverrides;
+    buildReport(reportPath, report);
+    console.log('npm i failed after removing overrides; changes were reverted.');
+    return 0;
+  }
+
+  const dedupRes = runCommand('npm dedup', repoRoot);
+  if (!dedupRes.ok) {
+    restoreWorkspace(
+      {
+        packageJsonPath,
+        packageJson: originalPackageJsonText,
+        packageLockPath,
+        packageLock: originalPackageLock,
+      },
+      repoRoot,
+    );
+    report.reverted = true;
+    report.reason = 'npm-dedup-failed';
+    report.removedOverrides = removedOverrides;
+    buildReport(reportPath, report);
+    console.log('npm dedup failed after removing overrides; changes were reverted.');
+    return 0;
+  }
+
+  const validation = runNxValidation(repoRoot);
+  report.validation = validation;
+  if (!validation.ok) {
+    restoreWorkspace(
+      {
+        packageJsonPath,
+        packageJson: originalPackageJsonText,
+        packageLockPath,
+        packageLock: originalPackageLock,
+      },
+      repoRoot,
+    );
+    report.reverted = true;
+    report.reason = `nx-${validation.failedTarget}-failed`;
+    report.removedOverrides = removedOverrides;
+    buildReport(reportPath, report);
+    console.log(
+      `Nx ${validation.failedTarget} failed after removing overrides; changes were reverted.`,
+    );
+    return 0;
+  }
+
+  const postAudit = runNpmAudit(repoRoot);
+  report.auditAfter = postAudit.summary;
+  report.removedOverrides = removedOverrides;
+
+  if (
+    !postAudit.ok ||
+    !baselineAudit.ok ||
+    postAudit.summary.total === null ||
+    baselineAudit.summary.total === null ||
+    postAudit.summary.total > baselineAudit.summary.total
+  ) {
+    restoreWorkspace(
+      {
+        packageJsonPath,
+        packageJson: originalPackageJsonText,
+        packageLockPath,
+        packageLock: originalPackageLock,
+      },
+      repoRoot,
+    );
+    report.reverted = true;
+    report.reason = 'audit-regressed';
+    buildReport(reportPath, report);
+    console.log(
+      'Audit regressed after removing overrides; changes were reverted.',
+    );
+    return 0;
+  }
+
+  report.applied = true;
+  report.reason = 'override-removed';
+  buildReport(reportPath, report);
+  console.log(
+    `Removed overrides for ${removedOverrides
+      .map((entry) => entry.dependencyName)
+      .join(', ')}.`,
+  );
+  return 0;
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+} else {
+  module.exports = {
+    parseArgs,
+    tryParseJson,
+    getDependencyName,
+    collectUpdatedDependencyNames,
+    runCommand,
+    summarizeAuditResult,
+    runNpmAudit,
+    removeMatchingOverrides,
+    runNxValidation,
+    restoreWorkspace,
+    main,
+  };
+}

--- a/tests/unit/reconcile-dependabot-overrides.spec.js
+++ b/tests/unit/reconcile-dependabot-overrides.spec.js
@@ -1,0 +1,77 @@
+const processor = require('../../scripts/reconcile-dependabot-overrides');
+
+describe('collectUpdatedDependencyNames', () => {
+  test('extracts dependency names from Dependabot metadata and strings', () => {
+    const names = processor.collectUpdatedDependencyNames(
+      JSON.stringify([
+        { 'dependency-name': 'undici' },
+        { dependency: { package: { name: 'yaml' } } },
+      ]),
+      'axios, lodash',
+    );
+
+    expect(names).toEqual(['undici', 'yaml', 'axios', 'lodash']);
+  });
+});
+
+describe('removeMatchingOverrides', () => {
+  test('removes top-level and nested override keys', () => {
+    const overrides = {
+      undici: '5.7.1',
+      '@nx/angular': {
+        picomatch: '4.0.0',
+      },
+    };
+
+    const removed = processor.removeMatchingOverrides(overrides, [
+      'undici',
+      'picomatch',
+      'missing',
+    ]);
+
+    expect(removed).toEqual([
+      { dependencyName: 'undici', removedPath: 'overrides["undici"]' },
+      {
+        dependencyName: 'picomatch',
+        removedPath: 'overrides["@nx/angular"]["picomatch"]',
+      },
+    ]);
+    expect(overrides).toEqual({});
+  });
+});
+
+describe('summarizeAuditResult', () => {
+  test('extracts the vulnerability total from npm audit json', () => {
+    const summary = processor.summarizeAuditResult({
+      metadata: {
+        vulnerabilities: {
+          total: 3,
+          low: 1,
+          moderate: 2,
+          high: 0,
+          critical: 0,
+        },
+      },
+    });
+
+    expect(summary).toEqual({
+      ok: true,
+      total: 3,
+      vulnerabilities: {
+        total: 3,
+        low: 1,
+        moderate: 2,
+        high: 0,
+        critical: 0,
+      },
+    });
+  });
+
+  test('returns an unusable summary when vulnerabilities are missing', () => {
+    expect(processor.summarizeAuditResult({})).toEqual({
+      ok: false,
+      total: null,
+      vulnerabilities: null,
+    });
+  });
+});

--- a/tests/unit/reconcile-dependabot-overrides.spec.js
+++ b/tests/unit/reconcile-dependabot-overrides.spec.js
@@ -1,4 +1,31 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const processor = require('../../scripts/reconcile-dependabot-overrides');
+
+describe('parseArgs', () => {
+  const originalArgv = process.argv.slice();
+
+  afterEach(() => {
+    process.argv = originalArgv.slice();
+  });
+
+  test('supports key=value and key value forms', () => {
+    process.argv = [
+      ...originalArgv.slice(0, 2),
+      '--updated-dependencies-json',
+      '{"foo":1}',
+      '--flag',
+      '--dependency-names=undici,axios',
+    ];
+
+    expect(processor.parseArgs()).toEqual({
+      'updated-dependencies-json': '{"foo":1}',
+      flag: true,
+      'dependency-names': 'undici,axios',
+    });
+  });
+});
 
 describe('collectUpdatedDependencyNames', () => {
   test('extracts dependency names from Dependabot metadata and strings', () => {
@@ -11,6 +38,45 @@ describe('collectUpdatedDependencyNames', () => {
     );
 
     expect(names).toEqual(['undici', 'yaml', 'axios', 'lodash']);
+  });
+});
+
+describe('restoreWorkspace', () => {
+  test('uses npm install without package lock when no original lockfile exists', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'override-restore-'));
+    const packageJsonPath = path.join(tmpDir, 'package.json');
+    const packageLockPath = path.join(tmpDir, 'package-lock.json');
+    fs.writeFileSync(packageJsonPath, '{"name":"fixture"}\n', 'utf8');
+    fs.writeFileSync(packageLockPath, 'stale-lock', 'utf8');
+
+    const childProcess = require('child_process');
+    const originalExecSync = childProcess.execSync;
+    const commands = [];
+
+    childProcess.execSync = (command) => {
+      commands.push(command);
+      return '';
+    };
+
+    try {
+      processor.restoreWorkspace(
+        {
+          packageJsonPath,
+          packageJson: '{"name":"fixture","private":true}\n',
+          packageLockPath,
+          packageLock: null,
+        },
+        tmpDir,
+      );
+    } finally {
+      childProcess.execSync = originalExecSync;
+    }
+
+    expect(commands).toEqual(['npm install --no-package-lock']);
+    expect(fs.readFileSync(packageJsonPath, 'utf8')).toBe(
+      '{"name":"fixture","private":true}\n',
+    );
+    expect(fs.existsSync(packageLockPath)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Add a Dependabot npm override cleanup flow that runs on Dependabot PRs, removes unneeded package.json overrides when the updated dependency no longer needs them, runs npm i/npm dedup plus Nx validation, and restores the workspace if the audit result gets worse.

The workflow updates the Dependabot PR branch in place and keeps the existing Nx migrate path intact for Nx dependency updates.