### PR TITLE
chore: upgrade Angular build tools and remove deprecated packages

### DIFF
--- a/apps/angular-auth-example/project.json
+++ b/apps/angular-auth-example/project.json
@@ -7,7 +7,7 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@angular-devkit/build-angular:application",
+      "executor": "@angular/build:application",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/apps/angular-auth-example",
@@ -50,7 +50,7 @@
       "defaultConfiguration": "production"
     },
     "serve": {
-      "executor": "@angular-devkit/build-angular:dev-server",
+      "executor": "@angular/build:dev-server",
       "configurations": {
         "production": {
           "buildTarget": "angular-auth-example:build:production"
@@ -67,7 +67,7 @@
       "continuous": true
     },
     "extract-i18n": {
-      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "executor": "@angular/build:extract-i18n",
       "options": {
         "buildTarget": "angular-auth-example:build"
       }

--- a/apps/nx-tinkering/project.json
+++ b/apps/nx-tinkering/project.json
@@ -7,7 +7,7 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@angular-devkit/build-angular:application",
+      "executor": "@angular/build:application",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/apps/nx-tinkering",
@@ -50,7 +50,7 @@
       "defaultConfiguration": "production"
     },
     "serve": {
-      "executor": "@angular-devkit/build-angular:dev-server",
+      "executor": "@angular/build:dev-server",
       "configurations": {
         "production": {
           "buildTarget": "nx-tinkering:build:production"
@@ -63,7 +63,7 @@
       "continuous": true
     },
     "extract-i18n": {
-      "executor": "@angular-devkit/build-angular:extract-i18n",
+      "executor": "@angular/build:extract-i18n",
       "options": {
         "buildTarget": "nx-tinkering:build"
       }

--- a/nx.json
+++ b/nx.json
@@ -19,7 +19,7 @@
     "sharedGlobals": []
   },
   "targetDefaults": {
-    "@angular-devkit/build-angular:application": {
+    "@angular/build:application": {
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@angular/core": "22.0.8",
     "@angular/forms": "22.0.8",
     "@angular/platform-browser": "22.0.8",
-    "@angular/platform-browser-dynamic": "22.0.8",
     "@angular/router": "22.0.8",
     "@microsoft/kiota-abstractions": "^1.0.0-preview.103",
     "@microsoft/kiota-serialization-form": "^1.0.0-preview.103",
@@ -36,8 +35,8 @@
     "zone.js": "0.16.2"
   },
   "devDependencies": {
+    "@angular/build": "22.0.8",
     "@angular-devkit/architect": "^0.2200.8",
-    "@angular-devkit/build-angular": "22.0.8",
     "@angular-devkit/core": "22.0.8",
     "@angular-devkit/schematics": "22.0.8",
     "@angular-eslint/eslint-plugin": "^22.1.0",
@@ -121,7 +120,7 @@
     "@angular/compiler-cli": {
       "@babel/core": "^7.29.6"
     },
-    "@angular-devkit/build-angular": {
+    "@angular/build": {
       "@babel/core": "^7.29.6",
       "vite": "^7.3.5",
       "esbuild": "0.28.1"


### PR DESCRIPTION
## Summary

Updates deprecated Angular packages to modern alternatives and removes unused dependencies:
- Removes `@angular/platform-browser-dynamic` (redundant with `bootstrapApplication`)
- Replaces `@angular-devkit/build-angular` with `@angular/build` (esbuild/Vite-based)
- Updates Angular app executors and build configurations

## What's changed

- **package.json**: Removed deprecated packages, added `@angular/build`
- **apps/angular-auth-example/project.json**: Updated executors to `@angular/build`
- **apps/nx-tinkering/project.json**: Updated executors to `@angular/build`
- **nx.json**: Updated targetDefaults for the new builder
- **package.json overrides**: Updated to reference `@angular/build`

## Why

This addresses npm install deprecation warnings and aligns with Angular's recommended build tooling. The esbuild-based builder provides better performance and is the official migration path from the Webpack-based `@angular-devkit/build-angular`.

## Testing

- Verify Angular apps build correctly: `nx build angular-auth-example` and `nx build nx-tinkering`
- Verify serve works: `nx serve angular-auth-example` and `nx serve nx-tinkering`

🤖 Generated with [Claude Code](https://claude.com/claude-code)